### PR TITLE
WIP: Bump to parcels version 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Launch Parcels Tutorials on mybinder.org
 
-[![Launch Parcels Examples in Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/willirath/parcels_examples_binder/master)
+[![Launch Parcels Examples in Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/willirath/parcels_examples_binder/master?urlpath=lab/tree/parcels_examples/parcels_tutorial.ipynb)

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -5,5 +5,6 @@ channels:
 dependencies:
   - python=3
   - cartopy
+  - ffmpeg
   - openblas
-  - parcels=2.0.0beta2
+  - parcels=2.0.0


### PR DESCRIPTION
See state of this PR in binder:

[![Launch Parcels Examples in Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/willirath/parcels_examples_binder/bump-to-v2.0.0?urlpath=lab/tree/parcels_examples/parcels_tutorial.ipynb)

Bump to parcels v2.0.0 and add ffmpeg to the dependencies.